### PR TITLE
Rename eip150 and eip158 schedules

### DIFF
--- a/vm-c/kevm/semantics.cpp
+++ b/vm-c/kevm/semantics.cpp
@@ -21,8 +21,8 @@ uint64_t get_schedule(mpz_ptr number, CallContext *ctx) {
   static uint32_t petersburg_tag = getTagForSymbolName("LblPETERSBURG'Unds'EVM{}");
   static uint32_t constantinople_tag = getTagForSymbolName("LblCONSTANTINOPLE'Unds'EVM{}");
   static uint32_t byzantium_tag = getTagForSymbolName("LblBYZANTIUM'Unds'EVM{}");
-  static uint32_t eip158_tag = getTagForSymbolName("LblEIP158'Unds'EVM{}");
-  static uint32_t eip150_tag = getTagForSymbolName("LblEIP150'Unds'EVM{}");
+  static uint32_t spuriousDragon_tag = getTagForSymbolName("LblSPURIOUS_DRAGON'Unds'EVM{}");
+  static uint32_t tangerineWhistle_tag = getTagForSymbolName("LblTANGERINE_WHISTLE'Unds'EVM{}");
   static uint32_t homestead_tag = getTagForSymbolName("LblHOMESTEAD'Unds'EVM{}");
   static uint32_t frontier_tag = getTagForSymbolName("LblFRONTIER'Unds'EVM{}");
   uint32_t tag;
@@ -37,13 +37,13 @@ uint64_t get_schedule(mpz_ptr number, CallContext *ctx) {
       if (mpz_cmp(number, byzantium) >= 0) {
         tag = byzantium_tag;
       } else {
-        mpz_ptr eip161 = to_z(ctx->ethereumconfig().eip161blocknumber());
-        if (mpz_cmp(number, eip161) >= 0) {
-          tag = eip158_tag;
+        mpz_ptr spuriousDragon = to_z(ctx->ethereumconfig().eip161blocknumber());
+        if (mpz_cmp(number, spuriousDragon) >= 0) {
+          tag = spuriousDragon_tag;
         } else {
-          mpz_ptr eip150 = to_z(ctx->ethereumconfig().eip150blocknumber());
-          if (mpz_cmp(number, eip150) >= 0) {
-            tag = eip150_tag;
+          mpz_ptr tangerineWhistle = to_z(ctx->ethereumconfig().eip150blocknumber());
+          if (mpz_cmp(number, tangerineWhistle) >= 0) {
+            tag = tangerineWhistle_tag;
           } else {
             mpz_ptr homestead = to_z(ctx->ethereumconfig().homesteadblocknumber());
             if (mpz_cmp(number, homestead) >= 0) {

--- a/vm/VM.ml
+++ b/vm/VM.ml
@@ -121,10 +121,10 @@ let get_schedule blocknum config = match config with
   if Z.geq blocknum danse then [KApply0(parse_klabel "DANSE_IELE-CONSTANTS")] else
   [KApply0(parse_klabel "ALBE_IELE-CONSTANTS")]
 | Ethereum_config cfg ->
-  let eip161 = World.to_z cfg.eip161_block_number in
-  if Z.geq blocknum eip161 then [KApply0(parse_klabel "SPURIOUS_DRAGON_EVM")] else
-  let eip150 = World.to_z cfg.eip150_block_number in
-  if Z.geq blocknum eip150 then [KApply0(parse_klabel "TANGERINE_WHISTLE_EVM")] else
+  let spuriousDragon = World.to_z cfg.eip161_block_number in
+  if Z.geq blocknum spuriousDragon then [KApply0(parse_klabel "SPURIOUS_DRAGON_EVM")] else
+  let tangerineWhistle = World.to_z cfg.eip150_block_number in
+  if Z.geq blocknum tangerineWhistle then [KApply0(parse_klabel "TANGERINE_WHISTLE_EVM")] else
   let homestead = World.to_z cfg.homestead_block_number in
   if Z.geq blocknum homestead then [KApply0(parse_klabel "HOMESTEAD_EVM")] else
   [KApply0(parse_klabel "FRONTIER_EVM")]

--- a/vm/VM.ml
+++ b/vm/VM.ml
@@ -122,9 +122,9 @@ let get_schedule blocknum config = match config with
   [KApply0(parse_klabel "ALBE_IELE-CONSTANTS")]
 | Ethereum_config cfg ->
   let eip161 = World.to_z cfg.eip161_block_number in
-  if Z.geq blocknum eip161 then [KApply0(parse_klabel "EIP158_EVM")] else
+  if Z.geq blocknum eip161 then [KApply0(parse_klabel "SPURIOUS_DRAGON_EVM")] else
   let eip150 = World.to_z cfg.eip150_block_number in
-  if Z.geq blocknum eip150 then [KApply0(parse_klabel "EIP150_EVM")] else
+  if Z.geq blocknum eip150 then [KApply0(parse_klabel "TANGERINE_WHISTLE_EVM")] else
   let homestead = World.to_z cfg.homestead_block_number in
   if Z.geq blocknum homestead then [KApply0(parse_klabel "HOMESTEAD_EVM")] else
   [KApply0(parse_klabel "FRONTIER_EVM")]


### PR DESCRIPTION
Rename the `eip150` and `eip158` schedules according to [#362](https://github.com/kframework/evm-semantics/pull/362)