### PR TITLE
use setter for thread local variable

### DIFF
--- a/vm-c/init.cpp
+++ b/vm-c/init.cpp
@@ -40,7 +40,7 @@ int init(int port, in_addr host) {
     perror("listen");
     exit(1);
   }
-  INTERVAL = 10000;
+  set_gc_interval(10000);
   return sock;
 }
 

--- a/vm-c/init.h
+++ b/vm-c/init.h
@@ -7,7 +7,7 @@
 
 extern "C" {
   void initStaticObjects(void);
-  extern thread_local uint64_t INTERVAL;
+  extern void set_gc_interval(uint64_t interval);
   size_t hook_LIST_size_long(list *l);
   block* hook_LIST_get_long(list *l, size_t i);
   list hook_MAP_values(map *m);


### PR DESCRIPTION
This should fix a bug during linking on Mac OS and also update us to the latest version of the llvm backend.