### PR TITLE
HttpHandler: Count both square brackets and braces in doneReading

### DIFF
--- a/client-c/HttpHandler.cpp
+++ b/client-c/HttpHandler.cpp
@@ -73,12 +73,26 @@ void HttpHandler::onError(ProxygenError /*err*/) noexcept { delete this; }
 
 bool HttpHandler::doneReading (char *buffer) {
   for(int i = 0; i < strlen(buffer); i++){
-    if('{' == buffer[i]){
-      bracket_counter_++;
-    } else if ('}' == buffer[i]) {
-      bracket_counter_--;
+    switch (buffer[i]){
+      case '{': {
+        brace_counter_++;
+        break;
+        }
+      case '}':{
+        brace_counter_--;
+        break;
+      }
+      case '[':{
+        bracket_counter_++;
+        break;
+      }
+      case ']':{
+        bracket_counter_--;
+        break;
+      }
     }
   }
-  return bracket_counter_ == 0;
+  return 0 == brace_counter_
+      && 0 == bracket_counter_;
 }
 }

--- a/client-c/HttpHandler.h
+++ b/client-c/HttpHandler.h
@@ -42,6 +42,7 @@ class HttpHandler : public proxygen::RequestHandler {
   HttpStats* const stats_{nullptr};
   int k_socket_;
   int bracket_counter_;
+  int brace_counter_;
   folly::Optional<proxygen::HTTPMethod> request_method_;
 };
 


### PR DESCRIPTION
This is required for the test files which contain a list of JSON objects.