### PR TITLE
Close HTTPServer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,8 @@ pipeline {
                         trackingSubmodules: false]], 
           userRemoteConfigs: [[url: 'git@github.com:facebook/proxygen.git']]])
           sh '''
-            cd proxygen
-            ./build.sh --no-jemalloc --no-install-dependencies
-            ./install.sh
+            cd proxygen && ./build.sh --no-jemalloc --no-install-dependencies
+            cd _build   && make install
           '''
         }
         sh 'make -j16'

--- a/client-c/HttpHandler.cpp
+++ b/client-c/HttpHandler.cpp
@@ -29,6 +29,7 @@ namespace HttpService {
 HttpHandler::HttpHandler(HttpStats* stats, int k_socket): stats_(stats),
                                                           k_socket_(k_socket),
                                                           bracket_counter_(0),
+                                                          brace_counter_(0),
                                                           request_method_(folly::none) {
 }
 

--- a/client-c/HttpHandler.cpp
+++ b/client-c/HttpHandler.cpp
@@ -51,7 +51,7 @@ void HttpHandler::onBody(std::unique_ptr<folly::IOBuf> r_body) noexcept {
       ret = recv(k_socket_, buffer, 4096, 0);
       buffer[ret] = 0x00;
       message += buffer;
-    } while (ret > 0 && false == doneReading(buffer));
+    } while (ret > 0 && false == doneReading(buffer) && false == peek(k_socket_));
 
     ResponseBuilder(downstream_)
       .status(200, "OK")
@@ -72,6 +72,12 @@ void HttpHandler::requestComplete() noexcept {
 
 void HttpHandler::onError(ProxygenError /*err*/) noexcept { delete this; }
 
+bool HttpHandler::peek(int socket) {
+  char *buffer[2] = {0};
+  int ret = recv(socket, buffer, 1, MSG_PEEK);
+  return buffer[0] == '{' 
+      || buffer[0] == '[';
+}
 bool HttpHandler::doneReading (char *buffer) {
   for(int i = 0; i < strlen(buffer); i++){
     switch (buffer[i]){

--- a/client-c/HttpHandler.h
+++ b/client-c/HttpHandler.h
@@ -38,12 +38,14 @@ class HttpHandler : public proxygen::RequestHandler {
 
   bool doneReading(char *buffer);
 
-  bool peek(int socket);
+  void countBrackets(const char *buffer);
+
  private:
   HttpStats* const stats_{nullptr};
   int k_socket_;
   int bracket_counter_;
   int brace_counter_;
+  int object_counter_;
   folly::Optional<proxygen::HTTPMethod> request_method_;
 };
 

--- a/client-c/HttpHandler.h
+++ b/client-c/HttpHandler.h
@@ -46,6 +46,7 @@ class HttpHandler : public proxygen::RequestHandler {
   int bracket_counter_;
   int brace_counter_;
   int object_counter_;
+  std::string body_;
   folly::Optional<proxygen::HTTPMethod> request_method_;
 };
 

--- a/client-c/HttpHandler.h
+++ b/client-c/HttpHandler.h
@@ -38,6 +38,7 @@ class HttpHandler : public proxygen::RequestHandler {
 
   bool doneReading(char *buffer);
 
+  bool peek(int socket);
  private:
   HttpStats* const stats_{nullptr};
   int k_socket_;


### PR DESCRIPTION
Changes:
- The response should contain the same number of `jsonrpc` messages as the request.
- The rpc message is now sent to the `kevm` from the `onEOM()` handle, which is triggered once the entire body of the http request is received.