### PR TITLE
Quieter Web3 server on successful connections

### DIFF
--- a/client-c/main.cpp
+++ b/client-c/main.cpp
@@ -226,7 +226,7 @@ void runKServer(HTTPServer *server) {
 void openSocket() {
   struct sockaddr_in k_addr;
   int sec = 0;
-  int ret;
+  int ret = -1;
   if ((K_SOCKET = socket(AF_INET, SOCK_STREAM, 0)) < 0)
   {
       std::cerr << "\n Socket creation error \n";
@@ -239,16 +239,16 @@ void openSocket() {
   // Convert IPv4 and IPv6 addresses from text to binary form
   if(inet_pton(AF_INET, "127.0.0.1", &k_addr.sin_addr) <= 0)
   {
-      std::cerr << "\nInvalid address/ Address not supported \n";
-      return;
+    std::cerr << "\nInvalid address/ Address not supported \n";
+    return;
   }
-  do {
-    if (sec > 0) {
-      std::cerr << "Socket connection to K Server failed, retrying in " << sec << "..." << std::endl;
-    }
+  while (ret != 0 && sec < 4) {
     sleep(sec);
     ret = connect(K_SOCKET, (struct sockaddr *)&k_addr, sizeof(k_addr));
     sec++;
-  } while(ret == -1);
+  }
+  if (ret != 0) {
+    std::cerr << "Socket connection to K Server failed, tried " << sec << " times." << std::endl;
+  }
   std::cout << "Socket connection to K Server is open\n";
 }


### PR DESCRIPTION
We were unconditionally outputting a "Socket connection failed ..." message on close of the server. This makes it so the happy path (no crash of server) doesn't take any additional time, but we also skip outputting that message accidentally.

KEVM PR: https://github.com/kframework/evm-semantics/pull/619