### PR TITLE
remove llvm backend checkout from build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,23 +14,6 @@ pipeline {
     stage('Test compilation') {
       when { changeRequest() }
       steps {
-        dir ('llvm-backend') {
-          checkout([$class: 'GitSCM',
-          branches: [[name: '*/master']],
-          extensions: [[$class: 'SubmoduleOption',
-                        disableSubmodules: false,
-                        parentCredentials: false,
-                        recursiveSubmodules: true,
-                        reference: '',
-                        trackingSubmodules: false]],
-          userRemoteConfigs: [[url: 'git@github.com:kframework/llvm-backend.git']]])
-          sh '''
-            mkdir build
-            cd build
-            cmake .. -DCMAKE_BUILD_TYPE=Release
-            make include
-          '''
-        }
         dir ('libff') {
           checkout([$class: 'GitSCM',
           branches: [[name: '*/master']],

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CPPFLAGS += -I llvm-backend/build/include -I llvm-backend/include -I dummy-version -I plugin -I plugin-c -I libff/build/install/include -I deps/cpp-httplib
+CPPFLAGS += -I /usr/lib/kframework/include -I dummy-version -I plugin -I plugin-c -I libff/build/install/include -I deps/cpp-httplib
 CXX=clang++-8
 
 .PHONY: build


### PR DESCRIPTION
Now that we use the K dockerfile, we can simplify our build by removing the LLVM backend checkout.