### PR TITLE
Web3: Close the write end of the K Server's pipe

### DIFF
--- a/client-c/main.cpp
+++ b/client-c/main.cpp
@@ -261,7 +261,7 @@ void runKServer(httplib::Server *svr) {
   block* final_config = take_steps(K_DEPTH, init_config);
   if (FLAGS_dump) printConfiguration("/dev/stderr", final_config);
   close(K_WRITE_FD);
-  close(K_READ_FD);
+  close(output[1]);
   svr->stop();
 }
 


### PR DESCRIPTION
When the web3 semantics get stuck, the entire client is supposed to shutdown. This wasn't happening because the pipe that the K Server communicates to the http server with wasn't being closed properly, so the http server was hanging in a blocking `read` call. This PR fixes that issue.

This PR also updates the `cpp-httplib` submodule to the latest master.

Sister PR: https://github.com/kframework/evm-semantics/pull/878