### PR TITLE
Add sha512_256 hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(INSTALL_INCLUDE)/$(PLUGIN_NAMESPACE)/%.md: plugin/%.md
 
 clean:
 	rm -rf */*.o */*/*.o build deps/libff/build
-	cd deps/secp256k1 && $(MAKE) clean
+	cd deps/secp256k1 && test ! -f Makefile || $(MAKE) clean
 
 # libcryptopp
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifeq ($(shell uname -s),Darwin)
 # 1. OSX doesn't have /proc/ filesystem
 # 2. fix cmake openssl detection for brew
 LIBFF_CMAKE_FLAGS += -DWITH_PROCPS=OFF \
-                     -DOPENSSL_ROOT_DIR=/usr/local/opt/$(shell brew desc openssl | cut -f1 -d:)
+                     -DOPENSSL_ROOT_DIR=$(shell brew --prefix openssl)
 else
 # llvm-backend code doesn't play nice with g++
 export CXX := $(if $(findstring default, $(origin CXX)), clang++, $(CXX))

--- a/plugin-c/crypto.cpp
+++ b/plugin-c/crypto.cpp
@@ -28,24 +28,25 @@ struct string *hook_KRYPTO_sha512(struct string *str) {
   return hexEncode(digest, sizeof(digest));
 }
 
-bool sha512_256(struct string *input, unsigned char *result) {
+void sha512_256(struct string *input, unsigned char *result) {
   EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-  return ctr != NULL
-      && EVP_DigestInit_ex(ctx, EVP_sha512_256(), NULL) == 1
-      && EVP_DigestUpdate(ctx, input->data, len(input)) == 1
-      && EVP_DigestFinal_ex(ctx, result, NULL) == 1
-      && EVP_MD_CTX_free(ctx) == 1;
+  bool success = ctx != NULL                                 \
+      && EVP_DigestInit_ex(ctx, EVP_sha512_256(), NULL) == 1 \
+      && EVP_DigestUpdate(ctx, input->data, len(input)) == 1 \
+      && EVP_DigestFinal_ex(ctx, result, NULL) == 1;
+  if (! success) throw std::runtime_error("openssl sha512_256 EVP_Digest runtime error");
+  EVP_MD_CTX_free(ctx);
 }
 
 struct string *hook_KRYPTO_sha512_256raw(struct string *str) {
   unsigned char digest[32];
-  if (sha512_256(digest, str)) exit(1);
+  sha512_256(str, digest);
   return raw(digest, sizeof(digest));
 }
 
 struct string *hook_KRYPTO_sha512_256(struct string *str) {
   unsigned char digest[32];
-  if (sha512_256(digest, str)) exit(1);
+  sha512_256(str, digest);
   return hexEncode(digest, sizeof(digest));
 }
 

--- a/plugin-c/crypto.cpp
+++ b/plugin-c/crypto.cpp
@@ -5,6 +5,7 @@
 #include <secp256k1_recovery.h>
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <libff/common/profiling.hpp>
+#include <openssl/evp.h>
 #include "blake2.h"
 #include "plugin_util.h"
 
@@ -28,17 +29,27 @@ struct string *hook_KRYPTO_sha512(struct string *str) {
 }
 
 struct string *hook_KRYPTO_sha512_256raw(struct string *str) {
-  SHA512 h;
-  unsigned char digest[64];
-  h.CalculateDigest(digest, (unsigned char *)str->data, len(str));
-  return raw(digest, 32);
+  unsigned char digest[32];
+  unsigned int digest_len = 32;
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+  assert(ctx != NULL);
+  assert(EVP_DigestInit_ex(ctx, EVP_sha512_256(), NULL)              == 1);
+  assert(EVP_DigestUpdate(ctx, (unsigned char *)str->data, len(str)) == 1);
+  assert(EVP_DigestFinal_ex(ctx, digest, &digest_len)                == 1);
+  EVP_MD_CTX_free(ctx);
+  return raw(digest, sizeof(digest));
 }
 
 struct string *hook_KRYPTO_sha512_256(struct string *str) {
-  SHA512 h;
-  unsigned char digest[64];
-  h.CalculateDigest(digest, (unsigned char *)str->data, len(str));
-  return hexEncode(digest, 32);
+  unsigned char digest[32];
+  unsigned int digest_len = 32;
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+  assert(ctx != NULL);
+  assert(EVP_DigestInit_ex(ctx, EVP_sha512_256(), NULL)              == 1);
+  assert(EVP_DigestUpdate(ctx, (unsigned char *)str->data, len(str)) == 1);
+  assert(EVP_DigestFinal_ex(ctx, digest, &digest_len)                == 1);
+  EVP_MD_CTX_free(ctx);
+  return hexEncode(digest, sizeof(digest));
 }
 
 struct string *hook_KRYPTO_sha3raw(struct string *str) {

--- a/plugin-c/crypto.cpp
+++ b/plugin-c/crypto.cpp
@@ -27,6 +27,20 @@ struct string *hook_KRYPTO_sha512(struct string *str) {
   return hexEncode(digest, sizeof(digest));
 }
 
+struct string *hook_KRYPTO_sha512_256raw(struct string *str) {
+  SHA512 h;
+  unsigned char digest[64];
+  h.CalculateDigest(digest, (unsigned char *)str->data, len(str));
+  return raw(digest, 32);
+}
+
+struct string *hook_KRYPTO_sha512_256(struct string *str) {
+  SHA512 h;
+  unsigned char digest[64];
+  h.CalculateDigest(digest, (unsigned char *)str->data, len(str));
+  return hexEncode(digest, 32);
+}
+
 struct string *hook_KRYPTO_sha3raw(struct string *str) {
   SHA3_256 h;
   unsigned char digest[32];

--- a/plugin-c/crypto.cpp
+++ b/plugin-c/crypto.cpp
@@ -28,27 +28,24 @@ struct string *hook_KRYPTO_sha512(struct string *str) {
   return hexEncode(digest, sizeof(digest));
 }
 
+bool sha512_256(struct string *input, unsigned char *result) {
+  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+  return ctr != NULL
+      && EVP_DigestInit_ex(ctx, EVP_sha512_256(), NULL) == 1
+      && EVP_DigestUpdate(ctx, input->data, len(input)) == 1
+      && EVP_DigestFinal_ex(ctx, result, NULL) == 1
+      && EVP_MD_CTX_free(ctx) == 1;
+}
+
 struct string *hook_KRYPTO_sha512_256raw(struct string *str) {
   unsigned char digest[32];
-  unsigned int digest_len = 32;
-  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-  assert(ctx != NULL);
-  assert(EVP_DigestInit_ex(ctx, EVP_sha512_256(), NULL)              == 1);
-  assert(EVP_DigestUpdate(ctx, (unsigned char *)str->data, len(str)) == 1);
-  assert(EVP_DigestFinal_ex(ctx, digest, &digest_len)                == 1);
-  EVP_MD_CTX_free(ctx);
+  if (sha512_256(digest, str)) exit(1);
   return raw(digest, sizeof(digest));
 }
 
 struct string *hook_KRYPTO_sha512_256(struct string *str) {
   unsigned char digest[32];
-  unsigned int digest_len = 32;
-  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-  assert(ctx != NULL);
-  assert(EVP_DigestInit_ex(ctx, EVP_sha512_256(), NULL)              == 1);
-  assert(EVP_DigestUpdate(ctx, (unsigned char *)str->data, len(str)) == 1);
-  assert(EVP_DigestFinal_ex(ctx, digest, &digest_len)                == 1);
-  EVP_MD_CTX_free(ctx);
+  if (sha512_256(digest, str)) exit(1);
   return hexEncode(digest, sizeof(digest));
 }
 

--- a/plugin/krypto.md
+++ b/plugin/krypto.md
@@ -33,6 +33,7 @@ In hooked hash functions, `String` inputs are interpreted as byte arrays, i.e. t
     syntax String ::= Keccak256 ( String )                            [function, hook(KRYPTO.keccak256)]
                     | Sha256 ( String )                               [function, hook(KRYPTO.sha256)]
                     | Sha512 ( String )                               [function, hook(KRYPTO.sha512)]
+                    | "Sha512_256" "(" String ")"                     [function, hook(KRYPTO.sha512_256)]
                     | "Sha3_256" "(" String ")"                       [function, hook(KRYPTO.sha3)]
                     | RipEmd160 ( String )                            [function, hook(KRYPTO.ripemd160)]
                     | Blake2Compress ( String )                       [function, hook(KRYPTO.blake2compress)]
@@ -47,6 +48,7 @@ These functions compute the same hash function as those named above except that 
     syntax String ::= Keccak256raw ( String )                         [function, hook(KRYPTO.keccak256raw)]
                     | Sha256raw ( String )                            [function, hook(KRYPTO.sha256raw)]
                     | Sha512raw ( String )                            [function, hook(KRYPTO.sha512raw)]
+                    | "Sha512_256raw" "(" String ")"                  [function, hook(KRYPTO.sha512_256raw)]
                     | "Sha3_256raw" "(" String ")"                    [function, hook(KRYPTO.sha3raw)]
                     | RipEmd160raw ( String )                         [function, hook(KRYPTO.ripemd160raw)]
  // -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This hook is needed for the TEAL/Clarity semantics.

The hook has been tested against a known input and output pair and passed.

I also fixed a bug in our make clean command which makes it succeed even if our submodules haven't been initialized.