### PR TITLE
Build libcryptopp, libsecp256k1 and libff in flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,28 +54,27 @@ clean:
 
 # libcryptopp
 
-libcryptopp: $(PREFIX)/lib/libcryptopp.a
-$(PREFIX)/lib/libcryptopp.a:
+libcryptopp: $(PREFIX)/libcryptopp/lib/libcryptopp.a
+$(PREFIX)/libcryptopp/lib/libcryptopp.a:
 	cd deps/cryptopp                      \
 	  && $(MAKE)                          \
-	  && $(MAKE) install PREFIX=$(PREFIX)
+	  && $(MAKE) install PREFIX=$(PREFIX)/libcryptopp
 
 # libff
 
-libff: $(PREFIX)/lib/libff.a
-$(PREFIX)/lib/libff.a:
-	@mkdir -p deps/libff/build
-	cd deps/libff/build                                                 \
-	  && cmake .. -DCMAKE_INSTALL_PREFIX=$(PREFIX) $(LIBFF_CMAKE_FLAGS) \
+libff: $(PREFIX)/libff/lib/libff.a
+$(PREFIX)/libff/lib/libff.a:
+	cd deps/libff                                                 \
+	  && cmake . -DCMAKE_INSTALL_PREFIX=$(PREFIX)/libff $(LIBFF_CMAKE_FLAGS) \
 	  && $(MAKE)                                                        \
 	  && $(MAKE) install
 
 # libsecp256k1
 
-libsecp256k1: $(PREFIX)/lib/pkgconfig/libsecp256k1.pc
-$(PREFIX)/lib/pkgconfig/libsecp256k1.pc:
+libsecp256k1: $(PREFIX)/libsecp256k1/lib/pkgconfig/libsecp256k1.pc
+$(PREFIX)/libsecp256k1/lib/pkgconfig/libsecp256k1.pc:
 	cd deps/secp256k1/                                             \
 	    && ./autogen.sh                                            \
-	    && ./configure --enable-module-recovery --prefix=$(PREFIX) \
+	    && ./configure --enable-module-recovery --prefix=$(PREFIX)/libsecp256k1 \
 	    && $(MAKE)                                                 \
 	    && $(MAKE) install


### PR DESCRIPTION
To have better control over the libcryptopp, libsecp256k1 and libff libraries we should be building them from source rather than relying on nix/systmem provided ones, as these will be a different version to the ones in tree in this repo.

This PR adds a nix derivation which builds libcryptopp, libsecp256k1 and libff, producing static `.a` libraries.