### PR TITLE
Add `-fPIC` to compiler flags for libff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ PREFIX ?= $(CURDIR)/build
 
 K_RELEASE ?= $(dir $(shell which kompile))..
 
+LIBFF_CMAKE_FLAGS += -DCMAKE_CXX_FLAGS=-fPIC
+
 # set OS specific defaults
 ifeq ($(shell uname -s),Darwin)
 # 1. OSX doesn't have /proc/ filesystem


### PR DESCRIPTION
I think this should pass `-fPIC` through to the libff build steps; a cursory search suggests that the other libraries already set the flag internally which might suggest why they don't exhibit the same issue.