### PR TITLE
Build PIC secp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,6 @@ libsecp256k1: $(PREFIX)/libsecp256k1/lib/pkgconfig/libsecp256k1.pc
 $(PREFIX)/libsecp256k1/lib/pkgconfig/libsecp256k1.pc:
 	cd deps/secp256k1/                                             \
 	    && ./autogen.sh                                            \
-	    && ./configure --enable-module-recovery --prefix=$(PREFIX)/libsecp256k1 \
+	    && CFLAGS='-fPIC' ./configure --enable-module-recovery --prefix=$(PREFIX)/libsecp256k1 \
 	    && $(MAKE)                                                 \
 	    && $(MAKE) install


### PR DESCRIPTION
We were not building a position-independent version of libsecp256k1 in the static -> shared workflow used by the new plugin build. This PR fixes that issue and allows me to build KEVM shared libraries locally.