### PR TITLE
update to latest version of llvm backend

### DIFF
--- a/plugin-c/json.cpp
+++ b/plugin-c/json.cpp
@@ -113,7 +113,7 @@ struct KoreHandler : BaseReaderHandler<UTF8<>, KoreHandler> {
     stringinj *inj = (stringinj *)koreAlloc(sizeof(stringinj));
     inj->h = strHdr;
     string *token = (string *)koreAllocToken(sizeof(string) + len);
-    set_len(token, len);
+    init_with_len(token, len);
     memcpy(token->data, str, len);
     inj->data = token;
     result = (block *)inj;

--- a/plugin-c/plugin_util.cpp
+++ b/plugin-c/plugin_util.cpp
@@ -3,7 +3,7 @@
 extern "C" {
 string* allocString(size_t len) {
   struct string *result = (struct string *)koreAllocToken(len + sizeof(string));
-  set_len(result, len);
+  init_with_len(result, len);
   return result;
 }
 


### PR DESCRIPTION
The llvm backend changed the name of the set_len macro.