### PR TITLE
fix bug in automatic rules for making blake2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,9 @@ $(PREFIX)/libff/lib/libff.a:
 	  && $(MAKE)                                                        \
 	  && $(MAKE) install
 
+CXXFLAGS=-O3
 ifeq ($(shell uname -p),x86_64)
-plugin-c/blake2.a: CPPFLAGS=-mavx2
+plugin-c/blake2.a: CXXFLAGS+=-mavx2
 endif
 plugin-c/blake2.a: plugin-c/blake2.o plugin-c/blake2-avx2.o plugin-c/blake2-generic.o
 	ar qs plugin-c/blake2.a $^


### PR DESCRIPTION
I made an error when I created the build system for the avx2 blake2 code: I disabled compiling the blake2 code with optimizations. This made it slower rather than faster.

This PR ought to fix the issue.