### PR TITLE
Adapt recent refactorings for better downstream usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = deps/libff
 	url = https://github.com/scipr-lab/libff
 	ignore = untracked
-[submodule "deps/secp256k1"]
-	path = deps/secp256k1
-	url = https://github.com/bitcoin-core/secp256k1
-	ignore = untracked
 [submodule "deps/cryptopp"]
 	path = deps/cryptopp
 	url = https://github.com/weidai11/cryptopp

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifneq ($(APPLE_SILICON),)
 endif
 
 .PHONY: build libcryptopp libff
-build: blake2 plugin-c/json.o plugin-c/crypto.o plugin-c/plugin_util.o plugin-c/k.o
+build: libcryptopp libff blake2 plugin-c/json.o plugin-c/crypto.o plugin-c/plugin_util.o plugin-c/k.o
 
 .PHONY: install clean
 
@@ -72,12 +72,12 @@ $(PREFIX)/libff/lib/libff.a:
 
 # blake2
 
+blake2: $(PREFIX)/blake2/lib/blake2.a
+
 CXXFLAGS=-O3
 ifeq ($(shell uname -p),x86_64)
-plugin-c/blake2.a: CXXFLAGS+=-mavx2
+$(PREFIX)/blake2/lib/blake2.a: CXXFLAGS+=-mavx2
 endif
-
-blake2: $(PREFIX)/blake2/lib/blake2.a
 $(PREFIX)/blake2/lib/blake2.a: plugin-c/blake2.o plugin-c/blake2-avx2.o plugin-c/blake2-generic.o
 	mkdir -p $(dir $@)
 	ar qs $@ $^

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 export CXX := $(if $(findstring default, $(origin CXX)), clang++, $(CXX))
 endif
 
-INCLUDES := -I $(K_RELEASE)/include/kllvm -I $(PREFIX)/libcryptopp/include -I $(PREFIX)/libff/include -I dummy-version -I plugin -I plugin-c -I deps/cpp-httplib
+INCLUDES := -I $(K_RELEASE)/include/kllvm -I $(K_RELEASE)/include -I $(PREFIX)/libcryptopp/include -I $(PREFIX)/libff/include -I dummy-version -I plugin -I plugin-c -I deps/cpp-httplib
 CPPFLAGS += --std=c++17 $(INCLUDES)
 
 ifneq ($(APPLE_SILICON),)
@@ -32,7 +32,7 @@ ifneq ($(APPLE_SILICON),)
 endif
 
 .PHONY: build libcryptopp libff
-build: plugin-c/json.o plugin-c/blake2.a plugin-c/crypto.o plugin-c/plugin_util.o plugin-c/k.o
+build: blake2 plugin-c/json.o plugin-c/crypto.o plugin-c/plugin_util.o plugin-c/k.o
 
 .PHONY: install clean
 
@@ -52,7 +52,6 @@ $(INSTALL_INCLUDE)/$(PLUGIN_NAMESPACE)/%.md: plugin/%.md
 
 clean:
 	rm -rf */*.o */*/*.o build deps/libff/build
-	cd deps/secp256k1 && test ! -f Makefile || $(MAKE) clean
 
 # libcryptopp
 
@@ -71,9 +70,14 @@ $(PREFIX)/libff/lib/libff.a:
 	  && $(MAKE)                                                        \
 	  && $(MAKE) install
 
+# blake2
+
 CXXFLAGS=-O3
 ifeq ($(shell uname -p),x86_64)
 plugin-c/blake2.a: CXXFLAGS+=-mavx2
 endif
-plugin-c/blake2.a: plugin-c/blake2.o plugin-c/blake2-avx2.o plugin-c/blake2-generic.o
-	ar qs plugin-c/blake2.a $^
+
+blake2: $(PREFIX)/blake2/lib/blake2.a
+$(PREFIX)/blake2/lib/blake2.a: plugin-c/blake2.o plugin-c/blake2-avx2.o plugin-c/blake2-generic.o
+	mkdir -p $(dir $@)
+	ar qs $@ $^

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
             ${
               lib.strings.optionalString (stdenv.isAarch64 && stdenv.isDarwin)
               "APPLE_SILICON=true"
-            } make
+            } make libcryptopp libff blake2
           '';
           installPhase = ''
             mkdir -p $out/include

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
             ${
               lib.strings.optionalString (stdenv.isAarch64 && stdenv.isDarwin)
               "APPLE_SILICON=true"
-            } make build libcryptopp libff
+            } make
           '';
           installPhase = ''
             mkdir -p $out/include

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,7 @@
             ${
               lib.strings.optionalString (stdenv.isAarch64 && stdenv.isDarwin)
               "APPLE_SILICON=true"
-            } make libcryptopp libff
+            } make build libcryptopp libff
           '';
           installPhase = ''
             mkdir -p $out/include

--- a/tests/krypto-hooks/kryptotest.mak
+++ b/tests/krypto-hooks/kryptotest.mak
@@ -5,8 +5,8 @@ KOMPILE_FLAGS+=--hook-namespaces "KRYPTO" --md-selector "k | libcrypto-extra"
 
 PLUGIN_C=$(abspath $(MAKEFILE_PATH1)../../plugin-c)
 INCLUDES=-I$(abspath $(MAKEFILE_PATH1)../../build/libff/include) -I$(abspath $(MAKEFILE_PATH1)../../build/libcryptopp/include)
-LIBRARIES=$(abspath $(MAKEFILE_PATH1)../../build/libff/lib/libff.a) $(abspath $(MAKEFILE_PATH1)../../build/libcryptopp/lib/libcryptopp.a) -lssl -lcrypto -lprocps -lsecp256k1
-CPP_SOURCES=crypto.cpp plugin_util.cpp blake2.a hash_ext.cpp
+LIBRARIES=$(abspath $(MAKEFILE_PATH1)../../build/libff/lib/libff.a) $(abspath $(MAKEFILE_PATH1)../../build/libcryptopp/lib/libcryptopp.a) $(abspath $(MAKEFILE_PATH1)../../build/blake2/lib/blake2.a) -lssl -lcrypto -lprocps -lsecp256k1
+CPP_SOURCES=crypto.cpp plugin_util.cpp hash_ext.cpp
 
 KOMPILE_FLAGS+=$(addprefix -ccopt , $(INCLUDES) $(patsubst %, $(PLUGIN_C)/%, $(CPP_SOURCES)) $(LIBRARIES))
 


### PR DESCRIPTION
* Removes submodule `secp256k1` (but checkouts of earlier versions will still include it)
* moves `blake2.a` artefact to `build/blake2/lib` directory to align with conventions for `libff` and `libcryptopp` (`make clean` will now remove this file, too)
* calls `make blake2` in `flake.nix` build phase to build/provide `blake2.a` to clients.

These changes make using the plugin in downstream dependencies under `nix` a bit easier.
The dependent still needs to build the code from source (the `*.o` files are not provided) but does not have to replicate the build logic for the `blake2`  parts.
