### PR TITLE
Deprecate `klabel` attribute

### DIFF
--- a/krypto/src/tests/integration/test-data/ecdsa-test.k
+++ b/krypto/src/tests/integration/test-data/ecdsa-test.k
@@ -14,7 +14,7 @@ module ECDSA-TEST
     syntax Pgm ::= Bytes | String | Int | Account
  // ---------------------------------------------
 
-    syntax Int ::= #addrFromPrivateKey ( String ) [function, klabel(addrFromPrivateKey)]
+    syntax Int ::= #addrFromPrivateKey ( String ) [function, symbol(addrFromPrivateKey)]
  // ------------------------------------------------------------------------------------
     rule [addrFromPrivateKey]: #addrFromPrivateKey ( KEY ) => #addr( #parseHexWord( Keccak256( #parseByteStack( ECDSAPubKey( #parseByteStack( KEY ) ) ) ) ) )
 
@@ -79,8 +79,8 @@ module ECDSA-TEST
 
     syntax Account ::= Int
                      | ".Account"
-                     | #sender ( Bytes , Int , Bytes , Bytes ) [function, klabel(#senderAux)   ]
-                     | #sender ( Bytes )                       [function, klabel(#senderAux2)  ]
+                     | #sender ( Bytes , Int , Bytes , Bytes ) [function, symbol(#senderAux)   ]
+                     | #sender ( Bytes )                       [function, symbol(#senderAux2)  ]
  // -----------------------------------------------------------------------------------------------
     rule #sender(HT, TW, TR, TS) => #sender(ECDSARecover(HT, TW, TR, TS))
 

--- a/plugin/krypto.md
+++ b/plugin/krypto.md
@@ -110,7 +110,7 @@ The BN128 elliptic curve is defined over 2-dimensional points over the fields of
  // -----------------------------------------------------------------------------
 
     syntax Bool ::= isValidPoint(G1Point) [function, hook(KRYPTO.bn128valid)]
-                  | isValidPoint(G2Point) [function, klabel(isValidG2Point), hook(KRYPTO.bn128g2valid)]
+                  | isValidPoint(G2Point) [function, symbol(isValidG2Point), hook(KRYPTO.bn128g2valid)]
  // ---------------------------------------------------------------------------------------------------
 endmodule
 ```


### PR DESCRIPTION
This PR is a simple mechanical change to remove the `klabel, symbol` attribute pair in anticipation of `klabel` finally being deprecated; usages are replaced with 1-argument `symbol(_)`.