### PR TITLE
Compile the cryptopp lib with -fPIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test: build
 libcryptopp: $(PREFIX)/libcryptopp/lib/libcryptopp.a
 $(PREFIX)/libcryptopp/lib/libcryptopp.a:
 	cd deps/cryptopp                      		\
-	  && $(MAKE) CXXFLAGS="-DNDEBUG -g2 -O3" 	\
+	  && $(MAKE) CXXFLAGS="-DNDEBUG -g2 -O3 -fPIC" 	\
 	  && $(MAKE) install PREFIX=$(PREFIX)/libcryptopp
 
 


### PR DESCRIPTION
Should fix #152 

#173 made a change to how cryptopp is built which dropped the `-fPIC` flag, causing the plugin-c library that gets built to be unusable. This fixes that.