### PR TITLE
Replace `echo -n` with `printf` in trusted setup script for macOS compatibilty

### DIFF
--- a/create_trusted_setup_str.sh
+++ b/create_trusted_setup_str.sh
@@ -3,7 +3,7 @@
 IN=$1
 OUT=$2
 
-echo -n "const char *trusted_setup_str = R\"(" > "$OUT"
+printf '%s' 'const char *trusted_setup_str = R"(' > "$OUT"
 
 first_line=1
 while IFS='' read -r line; do


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/blockchain-k-plugin/pull/209/files#diff-dfe1fd0b454571329758f6b3a7537da645c3eca4c808d7ce8fe0707f582bb612.

This line in the trusted setup creation script https://github.com/runtimeverification/blockchain-k-plugin/blob/ed8437b23508e5ba64416b2f647a7aa3e703266d/create_trusted_setup_str.sh#L6
is causing the following issue on my macOS, where, apparently, it outputs a literal `-n` instead of suppressing the newline in a non-interactive `make` environment:
```sh
INFO 2025-02-17 15:20:33,882 pyk.utils - [PID=81041][stde] /private/var/folders/nm/0h7qd27j4c53c5k6crqzz16c0000gn/T/kdist-evm-semantics-plugin-7h42ufcc/build/c-kzg-4844/trusted_setup.cpp:1:1: error: expected external declaration
INFO 2025-02-17 15:20:33,882 pyk.utils - [PID=81041][stde] -n const char *trusted_setup_str = R"(
```

This PR fixes it by using `printf` instead of `echo -n`, producing the same result:
```
> echo -n "const char *trusted_setup_str = R\"("
const char *trusted_setup_str = R"(%
> printf '%s' 'const char *trusted_setup_str = R"('
const char *trusted_setup_str = R"(% 
```
