### PR TITLE
Fix macOS syntax error in kzg-4844 script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ $(PREFIX)/libff/lib/libff.a:
 
 C_KZG_4844 := $(CURDIR)/deps/c-kzg-4844
 C_KZG_4844_CFLAGS := -fPIC -O2 -I$(C_KZG_4844)/src -I$(C_KZG_4844)/inc
+C_KZG_4844_CXXFLAGS := $(C_KZG_4844_CFLAGS) -std=c++17
 
 $(PREFIX)/c-kzg-4844/trusted_setup.cpp: $(C_KZG_4844)/src/trusted_setup.txt
 	mkdir -p $(dir $@)
@@ -91,7 +92,7 @@ $(C_KZG_4844)/lib/libckzg.o: $(C_KZG_4844)/src/ckzg.c $(PREFIX)/c-kzg-4844/lib/l
 	$(CC) $(C_KZG_4844_CFLAGS) $< -c -o $@
 
 $(C_KZG_4844)/lib/trusted_setup.o: $(PREFIX)/c-kzg-4844/trusted_setup.cpp
-	$(CC) $(C_KZG_4844_CFLAGS) $< -c -o $@
+	$(CXX) $(C_KZG_4844_CXXFLAGS) $< -c -o $@
 
 $(PREFIX)/c-kzg-4844/lib/libckzg.a: $(C_KZG_4844)/lib/libckzg.o $(C_KZG_4844)/lib/trusted_setup.o $(PREFIX)/c-kzg-4844/lib/libblst.a
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/blockchain-k-plugin/pull/211, https://github.com/runtimeverification/blockchain-k-plugin/pull/210.

This PR adds another small fix for the PR https://github.com/runtimeverification/blockchain-k-plugin/pull/209, adding a hook for `verify_kzg_proof`. 

This line https://github.com/runtimeverification/blockchain-k-plugin/blob/e0b9fcf17c837859a2eb101f53710ab5d5cb8b0c/create_trusted_setup_str.sh#L6
causes the following error when I'm trying to build the plugin on a macOS:
```sh
INFO 2025-03-06 23:22:26,347 pyk.utils - [PID=52737][stde] /private/var/folders/nm/0h7qd27j4c53c5k6crqzz16c0000gn/T/kdist-evm-semantics-plugin-_hjgx1og/build/c-kzg-4844/trusted_setup.cpp:1:34: warning: missing terminating '"' character [-Winvalid-pp-token]
INFO 2025-03-06 23:22:26,348 pyk.utils - [PID=52737][stde] const char *trusted_setup_str = R"(4096
INFO 2025-03-06 23:22:26,348 pyk.utils - [PID=52737][stde]                                  ^
INFO 2025-03-06 23:22:26,348 pyk.utils - [PID=52737][stde] /private/var/folders/nm/0h7qd27j4c53c5k6crqzz16c0000gn/T/kdist-evm-semantics-plugin-_hjgx1og/build/c-kzg-4844/trusted_setup.cpp:1:33: error: use of undeclared identifier 'R'
INFO 2025-03-06 23:22:26,348 pyk.utils - [PID=52737][stde] const char *trusted_setup_str = R"(4096
INFO 2025-03-06 23:22:26,348 pyk.utils - [PID=52737][stde]                                 ^
INFO 2025-03-06 23:22:26,348 pyk.utils - [PID=52737][stde] /private/var/folders/nm/0h7qd27j4c53c5k6crqzz16c0000gn/T/kdist-evm-semantics-plugin-_hjgx1og/build/c-kzg-4844/trusted_setup.cpp:1:34: error: expected ';' after top level declarator
INFO 2025-03-06 23:22:26,349 pyk.utils - [PID=52737][stde] const char *trusted_setup_str = R"(4096
INFO 2025-03-06 23:22:26,349 pyk.utils - [PID=52737][stde]                                  ^
INFO 2025-03-06 23:22:26,349 pyk.utils - [PID=52737][stde]                                  ;
```
It seems that the syntax is only being recognized by C++ compiler, and Apple Clang++ (I have 15) uses c++98 as the standard by default, which doesn't recognize `R"` as a special character. This PR forces `-std=c++17` to be used with the cpp compiler (it is also enforced when building `plugin-c` in the Makefile).