### PR TITLE
Add hooks for multi-scalar-multiplication

### DIFF
--- a/krypto/src/tests/integration/test_hooks.py
+++ b/krypto/src/tests/integration/test_hooks.py
@@ -986,8 +986,6 @@ def test_verify_bls12g2oncurve(
     assert expected == actual
 
 
-
-
 # https://github.com/ethereum/execution-spec-tests/blob/b48d1dc81233af6e4d6c7c84e60e8eaa4067a288/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
 VERIFYBLS12G1MSM_TEST_DATA: Final = (
     ('g1_plus_inf', [BLS12_G1, BLS12_G1_INFTY], [1, 1], BLS12_G1),
@@ -1004,7 +1002,7 @@ VERIFYBLS12G1MSM_TEST_DATA: Final = (
 @pytest.mark.parametrize(
     'id, first,second,result', VERIFYBLS12G1MSM_TEST_DATA, ids=[id for id, *_ in VERIFYBLS12G1MSM_TEST_DATA]
 )
-def test_verify_bls12G1Msm(
+def test_verify_bls12g1msm(
     definition_dir: Path,
     id: str,
     first: list[tuple[int, int]],
@@ -1044,7 +1042,7 @@ VERIFYBLS12G2MSM_TEST_DATA: Final = (
 @pytest.mark.parametrize(
     'id, first,second,result', VERIFYBLS12G2MSM_TEST_DATA, ids=[id for id, *_ in VERIFYBLS12G2MSM_TEST_DATA]
 )
-def test_verify_bls12G2Msm(
+def test_verify_bls12g2msm(
     definition_dir: Path,
     id: str,
     first: list[tuple[tuple[int, int], tuple[int, int]]],

--- a/krypto/src/tests/integration/test_hooks.py
+++ b/krypto/src/tests/integration/test_hooks.py
@@ -984,3 +984,45 @@ def test_verify_bls12g2oncurve(
 
     # Then
     assert expected == actual
+
+
+
+
+# https://github.com/ethereum/execution-spec-tests/blob/b48d1dc81233af6e4d6c7c84e60e8eaa4067a288/tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1msm.py
+VERIFYBLS12G1MSM_TEST_DATA: Final = (
+    ('g1_plus_inf', [BLS12_G1, BLS12_G1_INFTY], [1, 1], BLS12_G1),
+    ('all_zero_scalars', [BLS12_G1, BLS12_G1_INFTY], [0, 0], BLS12_G1_INFTY),
+    ('sum_to_identity_opposite', [BLS12_G1, bls12_neg_g1(BLS12_G1)], [1, 1], BLS12_G1_INFTY),
+    ('scalars_sum_to_q', [BLS12_G1, BLS12_G1], [BLS12_Q - 1, 1], BLS12_G1_INFTY),
+    ('combined_basic_cases', [BLS12_G1, BLS12_G1, BLS12_G1_INFTY], [1, 0, 5], BLS12_G1),
+    ('identity_with_large_scalar', [BLS12_G1, BLS12_G1_INFTY], [1, 500], BLS12_G1),
+    ('multiple_points_zero_scalar', [BLS12_G1, BLS12_P1, bls12_neg_g1(BLS12_G1)], [0, 0, 0], BLS12_G1_INFTY),
+    ('max_discount', [BLS12_P1] * 3, [BLS12_Q] * 3, BLS12_G1_INFTY),
+)
+
+
+@pytest.mark.parametrize(
+    'id, first,second,result', VERIFYBLS12G1MSM_TEST_DATA, ids=[id for id, *_ in VERIFYBLS12G1MSM_TEST_DATA]
+)
+def test_verify_bls12G1Msm(
+    definition_dir: Path,
+    id: str,
+    first: list[tuple[int, int]],
+    second: list[int],
+    result: tuple[int, int],
+) -> None:
+    # Given
+    point_list = [f'ListItem(({x[0]} , {x[1]}))' for x in first]
+    scalar_list = [f'ListItem({x})' for x in second]
+    point_str = ' '.join(point_list)
+    scalar_str = ' '.join(scalar_list)
+    pgm = f'BLS12G1Msm( {scalar_str} , {point_str} )'
+
+    result_str = f'( {result[0]} , {result[1]} )'
+    expected = f'<k>\n  {result_str} ~> .K\n</k>'
+
+    # When
+    actual = run(definition_dir, pgm)
+
+    # Then
+    assert expected == actual

--- a/plugin-c/crypto.cpp
+++ b/plugin-c/crypto.cpp
@@ -443,6 +443,20 @@ g1point* blst_p1_to_g1point(const blst_p1 *p) {
   return result;
 }
 
+g2point* g2point_inf() {
+  struct g2point *result = (struct g2point *)kore_alloc(sizeof(struct g2point));
+
+  blockheader g2pointhdr =
+      get_block_header_for_symbol((uint64_t)get_tag_for_symbol_name("Lblg2Point{}"));
+  result->h = g2pointhdr;
+
+  result->x0 = zero_mpz_ptr();
+  result->y0 = zero_mpz_ptr();
+  result->x1 = zero_mpz_ptr();
+  result->y1 = zero_mpz_ptr();
+  return result;
+}
+
 g2point* blst_p2_to_g2point(const blst_p2 *p) {
   struct g2point *result = (struct g2point *)kore_alloc(sizeof(struct g2point));
 
@@ -647,6 +661,71 @@ struct g2point *hook_KRYPTO_bls12G2Mul(g2point *point, mpz_t scalar) {
   }
 
   blst_p2_mult(&result, &blstp, blstscalar.b, mpz_sizeinbase(scalar, 2));
+  return blst_p2_to_g2point(&result);
+}
+
+struct g2point *hook_KRYPTO_bls12G2Msm(list* scalars, list* g2) {
+  mpz_ptr scalars_size = hook_LIST_size(scalars);
+  mpz_ptr g2size = hook_LIST_size(g2);
+  unsigned long scalars_size_long = mpz_get_ui(scalars_size);
+  unsigned long g2size_long = mpz_get_ui(g2size);
+  mpz_clear(scalars_size);
+  mpz_clear(g2size);
+
+  if (scalars_size_long != g2size_long) {
+    throw std::invalid_argument("mismatched list sizes");
+  }
+
+  std::vector<blst_p2_affine> points(g2size_long);
+  std::vector<blst_scalar> blst_scalars(g2size_long);
+
+  int valid_point_count = 0;
+  int first_nbits = 0;
+  for (unsigned long i = 0; i < g2size_long; i++) {
+    inj *injg2 = (inj *)hook_LIST_get_long(g2, i);
+    g2point* g2pt = (g2point *)injg2->data;
+
+    if (!g2point_to_blst_p2_affine(&points[valid_point_count], g2pt)) {
+      throw std::invalid_argument("Invalid point");
+    }
+    if (blst_p2_affine_is_inf(&points[valid_point_count])) {
+      continue;
+    }
+
+    inj *injs = (inj *)hook_LIST_get_long(scalars, i);
+    mpz_ptr scalar = (mpz_ptr)injs->data;
+    if (valid_point_count == 0) {
+      first_nbits = mpz_cmp_ui(scalar, 0) == 0 ? 0 : mpz_sizeinbase(scalar, 2);
+    }
+    if (!mpz_ptr_to_blst_scalar(&blst_scalars[valid_point_count], scalar)) {
+      throw std::invalid_argument("Invalid scalar");
+    }
+    valid_point_count++;
+  }
+
+  if (valid_point_count == 0) {
+    return g2point_inf();
+  }
+  if (valid_point_count == 1) {
+    blst_p2 blstp;
+    blst_p2_from_affine(&blstp, &points[0]);
+    blst_p2 result;
+    blst_p2_mult(&result, &blstp, blst_scalars[0].b, first_nbits);
+    return blst_p2_to_g2point(&result);
+  }
+
+  size_t scratch_size = blst_p2s_mult_pippenger_scratch_sizeof(valid_point_count);
+  std::vector<limb_t> scratch(scratch_size / sizeof(limb_t) + 1);
+
+  const byte *scalars_arg[2] = {(byte *)blst_scalars.data(), NULL};
+  const blst_p2_affine *points_arg[2] = {points.data(), NULL};
+  blst_p2 result;
+  blst_p2s_mult_pippenger
+      ( &result
+      , points_arg, valid_point_count
+      , scalars_arg, sizeof(blst_scalars[0]) * 8
+      , scratch.data()
+      );
   return blst_p2_to_g2point(&result);
 }
 

--- a/plugin/krypto.md
+++ b/plugin/krypto.md
@@ -142,19 +142,20 @@ fit in 256 bits, or the field values do not fit in 384 bits, all BLS12_381
 functions evaluate to `#False`.
 
 ```k
-    syntax G1Point ::= BLS12G1Add        ( G1Point, G1Point )  [function, hook(KRYPTO.bls12G1Add)]
-    syntax G2Point ::= BLS12G2Add        ( G2Point, G2Point )  [function, hook(KRYPTO.bls12G2Add)]
-    syntax G1Point ::= BLS12G1Mul        ( G1Point, Int )      [function, hook(KRYPTO.bls12G1Mul)]
-    syntax G1Point ::= BLS12G1Msm        ( List, List )        [function, hook(KRYPTO.bls12G1Msm)]
-    syntax G2Point ::= BLS12G2Mul        ( G2Point, Int )      [function, hook(KRYPTO.bls12G2Mul)]
-    syntax Bool    ::= BLS12PairingCheck ( List, List)         [function, hook(KRYPTO.bls12PairingCheck)]
-    syntax G1Point ::= BLS12MapFpToG1    ( Int )               [function, hook(KRYPTO.bls12MapFpToG1)]
-    syntax G2Point ::= BLS12MapFp2ToG2   ( Int, Int )          [function, hook(KRYPTO.bls12MapFp2ToG2)]
+    syntax G1Point ::= BLS12G1Add        ( G1Point, G1Point )           [function, hook(KRYPTO.bls12G1Add)]
+    syntax G2Point ::= BLS12G2Add        ( G2Point, G2Point )           [function, hook(KRYPTO.bls12G2Add)]
+    syntax G1Point ::= BLS12G1Mul        ( G1Point, Int )               [function, hook(KRYPTO.bls12G1Mul)]
+    syntax G1Point ::= BLS12G1Msm        ( scalars:List, points:List )  [function, hook(KRYPTO.bls12G1Msm)]
+    syntax G2Point ::= BLS12G2Mul        ( G2Point, Int )               [function, hook(KRYPTO.bls12G2Mul)]
+    syntax G2Point ::= BLS12G2Msm        ( scalars:List, points:List )  [function, hook(KRYPTO.bls12G2Msm)]
+    syntax Bool    ::= BLS12PairingCheck ( List, List)                  [function, hook(KRYPTO.bls12PairingCheck)]
+    syntax G1Point ::= BLS12MapFpToG1    ( Int )                        [function, hook(KRYPTO.bls12MapFpToG1)]
+    syntax G2Point ::= BLS12MapFp2ToG2   ( Int, Int )                   [function, hook(KRYPTO.bls12MapFp2ToG2)]
 
-    syntax Bool    ::= BLS12G1InSubgroup ( G1Point )           [function, hook(KRYPTO.bls12G1InSubgroup)]
-    syntax Bool    ::= BLS12G2InSubgroup ( G2Point )           [function, hook(KRYPTO.bls12G2InSubgroup)]
-    syntax Bool    ::= BLS12G1OnCurve    ( G1Point )           [function, hook(KRYPTO.bls12G1OnCurve)]
-    syntax Bool    ::= BLS12G2OnCurve    ( G2Point )           [function, hook(KRYPTO.bls12G2OnCurve)]
+    syntax Bool    ::= BLS12G1InSubgroup ( G1Point )                    [function, hook(KRYPTO.bls12G1InSubgroup)]
+    syntax Bool    ::= BLS12G2InSubgroup ( G2Point )                    [function, hook(KRYPTO.bls12G2InSubgroup)]
+    syntax Bool    ::= BLS12G1OnCurve    ( G1Point )                    [function, hook(KRYPTO.bls12G1OnCurve)]
+    syntax Bool    ::= BLS12G2OnCurve    ( G2Point )                    [function, hook(KRYPTO.bls12G2OnCurve)]
 
     syntax Int ::= "BLS12_FIELD_MODULUS"  [alias]
     rule BLS12_FIELD_MODULUS => 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787

--- a/plugin/krypto.md
+++ b/plugin/krypto.md
@@ -145,6 +145,7 @@ functions evaluate to `#False`.
     syntax G1Point ::= BLS12G1Add        ( G1Point, G1Point )  [function, hook(KRYPTO.bls12G1Add)]
     syntax G2Point ::= BLS12G2Add        ( G2Point, G2Point )  [function, hook(KRYPTO.bls12G2Add)]
     syntax G1Point ::= BLS12G1Mul        ( G1Point, Int )      [function, hook(KRYPTO.bls12G1Mul)]
+    syntax G1Point ::= BLS12G1Msm        ( List, List )        [function, hook(KRYPTO.bls12G1Msm)]
     syntax G2Point ::= BLS12G2Mul        ( G2Point, Int )      [function, hook(KRYPTO.bls12G2Mul)]
     syntax Bool    ::= BLS12PairingCheck ( List, List)         [function, hook(KRYPTO.bls12PairingCheck)]
     syntax G1Point ::= BLS12MapFpToG1    ( Int )               [function, hook(KRYPTO.bls12MapFpToG1)]


### PR DESCRIPTION
https://github.com/Pi-Squared-Inc/evm-semantics/pull/42 has a corresponding commit that uses the new hooks.

The EVM semantics implementation used a naive and slow hand-built implementation for multi-scalar multiplication (i.e., computing `s1*p1+s2*p2+...+sn*pn`). There are two reasons for the new hooks:

1. We should not use hand-built algorithms for cryptographic stuff, even trivial ones like the EVM semantics used.
2. The Ethereum gas costs make sense only when using an efficient algorithm.