### PR TITLE
Blake2f: compress a copy of the state, not the caller's Bytes

### DIFF
--- a/krypto/src/tests/integration/conftest.py
+++ b/krypto/src/tests/integration/conftest.py
@@ -56,9 +56,20 @@ def definition_dir(krypto_kompile: Callable[..., Path]) -> Path:
 
         module TEST
             imports BOOL
+            imports BYTES
+            imports INT
+            imports K-EQUAL
+            imports STRING
             imports KRYPTO
             syntax Pgm ::= Bool | Bytes | String | G1Point | G2Point
             configuration <k> $PGM:Pgm </k>
+
+            // Passes the same Bytes term to Blake2Compress and to the check that
+            // follows it, so that a hook mutating its argument in place is observable.
+            syntax Bool ::= blake2NoAlias    ( Bytes )           [function]
+                          | blake2NoAliasAux ( String , Bytes )  [function]
+            rule blake2NoAlias(B) => blake2NoAliasAux(Blake2Compress(B), B)
+            rule blake2NoAliasAux(OUT, B) => lengthString(OUT) ==Int 128 andBool B ==K padRightBytes(b"", 213, 0)
         endmodule
     """
     return krypto_kompile(definition=definition, main_module='TEST', syntax_module='TEST')

--- a/krypto/src/tests/integration/test_hooks.py
+++ b/krypto/src/tests/integration/test_hooks.py
@@ -52,6 +52,11 @@ HOOK_TEST_DATA: Final = (
         '"08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b"',
     ),
     (
+        'Blake2CompressNoAliasing',
+        f"blake2NoAlias({hex2bytes(213 * '00')})",
+        'true',
+    ),
+    (
         'Keccak256raw',
         'Keccak256raw(b"foo")',
         r'b"A\xb1\xa0d\x97R\xaf\x1b(\xb3\xdc)\xa1Un\xeex\x1eJL:\x1f\x7fS\xf9\x0f\xa84\xde\t\x8cM"',

--- a/plugin-c/crypto.cpp
+++ b/plugin-c/crypto.cpp
@@ -192,7 +192,10 @@ struct string *hook_KRYPTO_blake2compress(struct string *params) {
   }
   unsigned char *data = (unsigned char *)params->data;
   uint32_t rounds = data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
-  uint64_t *h = (uint64_t *)&data[4];
+  // blake2b_compress updates h in place; params aliases the caller's Bytes,
+  // which the hook must not mutate, so compress a copy of the state.
+  uint64_t h[8];
+  memcpy(h, &data[4], sizeof(h));
   uint64_t *m = (uint64_t *)&data[68];
   uint64_t *t = (uint64_t *)&data[196];
   unsigned char f = data[212];


### PR DESCRIPTION
Changes:
- `plugin-c/crypto.cpp`: copy the 64-byte blake2 state to a local buffer before compressing.
- `krypto/src/tests/integration`: regression test that fails when the hook mutates its argument.

  - The new `Blake2CompressNoAliasing` case fails against the pre-fix hook and passes after it; the other Blake2 cases pass in both states, since the return value was never wrong.
